### PR TITLE
Fixed "`" for "’"

### DIFF
--- a/guide/ch02/index.md
+++ b/guide/ch02/index.md
@@ -300,7 +300,7 @@ using the `*staff` indicators.
 Once again, clefs, key signatures and meter signatures are encoded
 separately for each part. Notice how the meter signature has been
 encoded as 4/4 rather than `common time`. This again reflects
-<span class="rep">kern</span>`s preoccupation with functional
+<span class="rep">kern</span>’s preoccupation with functional
 information rather than orthographic information. (Later we will
 see how to encode the fact that the meter signature is visually
 rendered as `C` rather than 4/4.)
@@ -324,7 +324,7 @@ beginning and end of a slur respectively.
 
 The open square bracket `[` denotes the first note of a tie. The
 closed square bracket `]` denotes the last note of a tie. The
-underscore character `_` denotes middle notes (if any) of a tie.
+underscore character c_` denotes middle notes (if any) of a tie.
 
 Slurs and phrase markings can be *nested* (e.g. slurs within slurs)
 and may also be *elided* (e.g. overlapping phrases) to a single

--- a/guide/ch02/index.md
+++ b/guide/ch02/index.md
@@ -324,7 +324,7 @@ beginning and end of a slur respectively.
 
 The open square bracket `[` denotes the first note of a tie. The
 closed square bracket `]` denotes the last note of a tie. The
-underscore character c_` denotes middle notes (if any) of a tie.
+underscore character `_` denotes middle notes (if any) of a tie.
 
 Slurs and phrase markings can be *nested* (e.g. slurs within slurs)
 and may also be *elided* (e.g. overlapping phrases) to a single


### PR DESCRIPTION
Changed misplaced code quote (`) affecting a whole sentence for a regular smart quote (’)